### PR TITLE
Refactor module imports and require once in spec_helper

### DIFF
--- a/examples/event_scheduling.rb
+++ b/examples/event_scheduling.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../lib/csp/constraint'
-require_relative '../lib/csp/problem'
+require_relative '../lib/csp-resolver'
 
 module CSP
   module Examples

--- a/examples/map_coloring.rb
+++ b/examples/map_coloring.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../lib/csp/constraint'
-require_relative '../lib/csp/problem'
+require_relative '../lib/csp-resolver'
 
 module CSP
   module Examples

--- a/examples/queen.rb
+++ b/examples/queen.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../lib/csp/constraint'
-require_relative '../lib/csp/problem'
+require_relative '../lib/csp-resolver'
 
 module CSP
   module Examples

--- a/examples/sculpture.rb
+++ b/examples/sculpture.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../lib/csp/constraint'
-require_relative '../lib/csp/problem'
+require_relative '../lib/csp-resolver'
 
 module CSP
   module Examples

--- a/lib/csp-resolver.rb
+++ b/lib/csp-resolver.rb
@@ -2,6 +2,13 @@
 
 require_relative 'csp/version'
 require_relative 'csp/constraint'
+require_relative 'csp/utils'
+require_relative 'csp/algorithms/filtering/no_filter'
+require_relative 'csp/algorithms/ordering/no_order'
+require_relative 'csp/algorithms/lookahead/no_algorithm'
+require_relative 'csp/algorithms/lookahead/ac3'
+require_relative 'csp/algorithms/backtracking'
+require_relative 'csp/constraints'
 require_relative 'csp/problem'
 
 module CSP; end

--- a/lib/csp/algorithms/backtracking.rb
+++ b/lib/csp/algorithms/backtracking.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'filtering/no_filter'
-require_relative 'ordering/no_order'
-require_relative 'lookahead/no_algorithm'
 require 'forwardable'
 
 module CSP

--- a/lib/csp/constraints.rb
+++ b/lib/csp/constraints.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constraint'
-
 module CSP
   module Constraints
     class AllDifferentConstraint < CSP::Constraint

--- a/lib/csp/problem.rb
+++ b/lib/csp/problem.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'algorithms/backtracking'
-require_relative 'utils'
-require_relative 'constraints'
-
 module CSP
   # TODO: implement dependent factor with weight
   # TODO: implement lookahead, arc-consistency, ac3

--- a/spec/csp/algorithms/backtracking_spec.rb
+++ b/spec/csp/algorithms/backtracking_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'csp/algorithms/backtracking'
 
 RSpec.describe CSP::Algorithms::Backtracking do
   describe '#backtracking' do

--- a/spec/csp/algorithms/lookahead/ac3_spec.rb
+++ b/spec/csp/algorithms/lookahead/ac3_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../../../support/tshirt'
-require_relative '../../../../lib/csp/algorithms/lookahead/ac3'
 
 RSpec.describe CSP::Algorithms::Lookahead::Ac3 do
   describe '#call' do

--- a/spec/csp/constraint_spec.rb
+++ b/spec/csp/constraint_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'csp/constraint'
 
 RSpec.describe CSP::Constraint do
   describe '#satisfies?' do

--- a/spec/csp/constraints_spec.rb
+++ b/spec/csp/constraints_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'csp/constraints'
 
 RSpec.describe CSP::Constraints::AllDifferentConstraint do
   describe '#satisfies?' do

--- a/spec/csp/problem_spec.rb
+++ b/spec/csp/problem_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'csp/problem'
-require 'csp/constraints'
 
 RSpec.describe CSP::Problem do
   describe 'initialization' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'simplecov'
+require_relative '../lib/csp-resolver'
 
 if ENV['COVERAGE']
   SimpleCov.start do

--- a/spec/support/tshirt.rb
+++ b/spec/support/tshirt.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/csp/constraint'
-
 class Tshirt
   def people
     %w[A B C]


### PR DESCRIPTION
This PR refactors the module imports in the project. Now, modules are imported in a chain in the main module, avoiding duplicate imports. Additionally, only one module is imported in the spec_helper, allowing all tests to have access to the necessary modules.

Main changes:

- Remove individual module imports from core files
- Import modules in a chain in the main module
- Import only the main module in spec_helper

With these changes, the code becomes more organized, avoids unnecessary duplications, and maintains a single source of imports for tests. Only specific tests that don't solely depend on the CSP module need additional imports...